### PR TITLE
Build 'Create' new item feature

### DIFF
--- a/assets/scripts/templates/state-item-create.handlebars
+++ b/assets/scripts/templates/state-item-create.handlebars
@@ -1,12 +1,15 @@
 <!-- Empty form to create new item -->
-<form id="create-item" class="create-item" data-id="{{item.id}}">
+<form id="create-item" class="create-item" data-id="{{item}}">
   <fieldset>
-    <input type="text" name="items[title]" placeholder="Goal">
-    <input type="text" onfocus="(this.type='date')" onblur="(this.type='text')"  name="items[due_date]" placeholder="Last time viewed">
-    <input type="text" name="items[location]" placeholder="Location">
-    <input type="text" name="items[description]" placeholder="Location">
-    <input type="text" name="items[category]" placeholder="Location">
-    <button data-id="{{item.id}}" class="glyphicon glyphicon-ok-circle" type="button" name="Add"></button>
-    <button data-id="{{item.id}}" type="button" name="Cancel"></button>
+    <input type="text" name="item[title]" placeholder="Goal">
+    <input type="text" onfocus="(this.type='date')" onblur="(this.type='text')"  name="item[due_date]" placeholder="Last time viewed">
+    <!-- <input type="text" name="item[state]" placeholder="State"> -->
+    <input type="text" name="item[location]" placeholder="Location">
+    <input type="text" name="item[description]" placeholder="Description">
+    <input type="text" name="item[category]" placeholder="Category">
+    <input type="text" name="item[status]" placeholder="Status">
+    <!-- <button data-id="{{item.id}}" class="glyphicon glyphicon-ok-circle" type="button" name="Add">Add</button> -->
+    <input class="glyphicon glyphicon-ok-circle" data-id="{{item.id}}" type="submit" name="Submit" value="Create">
+    <button data-id="{{item.id}}" type="button" name="Cancel">Cancel</button>
   </fieldset>
 </form>

--- a/assets/scripts/usmap/api.js
+++ b/assets/scripts/usmap/api.js
@@ -15,7 +15,7 @@ const getItems = function () {
 }
 
 const createItem = function (content) {
-  console.log(content)
+  // console.log('inside api/createItem and the content is', content)
   return $.ajax({
     method: 'POST',
     url: config.apiOrigin + '/items',

--- a/assets/scripts/usmap/events.js
+++ b/assets/scripts/usmap/events.js
@@ -7,7 +7,7 @@ const api = require('./api')
 const ui = require('./ui')
 
 const onGetItems = function (element, code, region) {
-  // event.preventDefault()
+  event.preventDefault()
   api.getItems()
     .then((data) => {
       ui.getItemsSuccess(data, region)
@@ -15,13 +15,14 @@ const onGetItems = function (element, code, region) {
     .catch(ui.getItemsFailure)
 }
 
-const onCreateItem = function (event) {
-  const content = getFormFields(event.target)
-  event.preventDefault()
-  api.createItem(content)
-    .then(ui.createItemSuccess)
-    .catch(ui.createItemFailure)
-}
+// const onCreateItem = function (event) {
+//   console.log('inside events/onCreateItem')
+//   event.preventDefault()
+//   const content = getFormFields(event.target)
+//   api.createItem(content)
+//     .then(ui.createItemSuccess)
+//     .catch(ui.createItemFailure)
+// }
 
 const onUpdateItem = function (event) {
   const content = getFormFields(event.target)
@@ -57,13 +58,14 @@ const usMap = function () {
     selectedRegions: null,
     showTooltip: true,
     onRegionClick: function (element, code, region) {
+      console.log('what state did i click on?', region)
       onGetItems(element, code, region)
     }
   })
 }
 
 const addHandlers = () => {
-  $('#item-create').on('submit', onCreateItem)
+  // $('#create-item').on('submit', onCreateItem)
   $('#item-update').on('submit', onUpdateItem)
   $('#item-destroy').on('submit', onDestroyItem)
 }
@@ -71,6 +73,6 @@ const addHandlers = () => {
 module.exports = {
   addHandlers,
   usMap,
-  onCreateItem,
+  // onCreateItem,
   onUpdateItem
 }

--- a/assets/scripts/usmap/ui.js
+++ b/assets/scripts/usmap/ui.js
@@ -1,18 +1,58 @@
 'use strict'
+
+require('../jquery.vmap.js')
+require('../jquery.vmap.usa.js')
+const store = require('../store.js')
+
+const getFormFields = require(`../../../lib/get-form-fields`)
+
+const api = require('./api')
+const ui = require('./ui')
+// const onCreateItem = require('./events')
 // const showLandingTemplate = require('../templates/landing.handlebars')
 // const showMapTemplate = require('../templates/map.handlebars')
-// const showStateAllTemplate = require('../templates/state-all-items.handlebars')
-// const showStateItemCreateTemplate = require('../templates/state-item-create.handlebars')
+const showStateAllTemplate = require('../templates/state-all-items.handlebars')
+const showStateItemCreateTemplate = require('../templates/state-item-create.handlebars')
 // const showStateItemDetailsTemplate = require('../templates/state-item-details.handlebars')
 // const showStateItemUpdateTemplate = require('../templates/state-item-update.handlebars')
 
 const getItemsSuccess = (data, region) => {
+  // debugger
+  $('#state-view').append(showStateAllTemplate)
+  $('#state-view').append(showStateItemCreateTemplate)
+  $('#create-item').on('submit', onCreateItem)
   // console.log(data)
   // console.log('inside getItemsSucces region is', region)
   const result = data.items.filter((item) => {
     return item.state === region
   })
-  console.log(result)
+  console.log('result at getItemSuccess is', result)
+  console.log('what is state at getItemSuccess?', region)
+  store.state = region
+}
+
+const onCreateItem = function (event) {
+  console.log('what is store.state', store.state) // Michigan
+  event.preventDefault()
+  // console.log('event.target at onCreateItem is', event.target)
+  const content = getFormFields(event.target)
+  // console.log('inside ui/onCreateItem and the content is', content)
+
+  const newData = {
+    item: {
+      description: content.item.description,
+      due_date: content.item.due_date,
+      state: store.state,
+      status: content.item.status,
+      title: content.item.title,
+      category: content.item.category,
+      location: content.item.location
+    }
+  }
+
+  api.createItem(newData)
+    .then(ui.createItemSuccess)
+    .catch(ui.createItemFailure)
 }
 
 const getItemsFailure = (data) => {

--- a/index.html
+++ b/index.html
@@ -59,7 +59,8 @@
       <!-- State-all-items handlebar template start-->
       <!-- State-all-items handlebar template end-->
 
-
+      <!-- State-item-create handlebar template start-->
+      <!-- State-item-create handlebar template end-->
 
       <!-- State-item-details handlebar template start-->
       <!-- State-item-details handlebar template end-->


### PR DESCRIPTION
Appended showStateAllTemplate and showStateItemCreateTemplate handlebar
templates to state-view container in getItemsSuccess. This allowed us to
create a 'submit' handler for the submission event of a newly created
item. Now when a user clicks submit, the onCreateItem function is run,
sending a POST request to the API with the 'region' (alias for
the states) stored from when user initially clicked on the state
(store.state = region).

Note: In the onCreateItem, we created a 'newData' object that contains
the user-inputted content (description, due_date, status, title,
category, and location) and the stored state. In the API call, we pass
in this 'newData' object because our API requires all attributes,
including state.

Worked with Nikki Riser @nriser