### PR TITLE
Add cancel button for 'create' new item

### DIFF
--- a/assets/scripts/templates/state-all-items.handlebars
+++ b/assets/scripts/templates/state-all-items.handlebars
@@ -1,3 +1,4 @@
+<h2 id="state-header" class="state-header"></h2>
 
 <!-- req.body.item[i].title -->
 <div class="row checkbox">

--- a/assets/scripts/templates/state-item-create.handlebars
+++ b/assets/scripts/templates/state-item-create.handlebars
@@ -10,6 +10,6 @@
     <input class="form-control" type="text" name="item[status]" placeholder="Status">
     <!-- <button data-id="{{item.id}}" class="glyphicon glyphicon-ok-circle" type="button" name="Add">Add</button> -->
     <input class="form-control" class="glyphicon glyphicon-ok-circle" data-id="{{item.id}}" type="submit" name="Submit" value="Create">
-    <button data-id="{{item.id}}" type="button" name="Cancel">Cancel</button>
+    <button id="cancel-create" class="cancel-create" data-id="{{item.id}}" type="button" name="Cancel">Cancel</button>
   </fieldset>
 </form>

--- a/assets/scripts/usmap/ui.js
+++ b/assets/scripts/usmap/ui.js
@@ -7,27 +7,38 @@ const store = require('../store.js')
 const getFormFields = require(`../../../lib/get-form-fields`)
 
 const api = require('./api')
-const ui = require('./ui')
+// const ui = require('./ui')
 // const onCreateItem = require('./events')
 // const showLandingTemplate = require('../templates/landing.handlebars')
 const addItemToList = require('../templates/add-item-to-list.handlebars')
 const showStateAllTemplate = require('../templates/state-all-items.handlebars')
 const showStateItemCreateTemplate = require('../templates/state-item-create.handlebars')
-// const showStateItemDetailsTemplate = require('../templates/state-item-details.handlebars')
-// const showStateItemUpdateTemplate = require('../templates/state-item-update.handlebars')
-const mapPage = require('../templates/map.handlebars')
 const allGoals = require('../templates/all-goals.handlebars')
 const nextGoal = require('../templates/next-goal.handlebars')
+const mapPage = require('../templates/map.handlebars')
+const mapEvents = require('./events')
 
 
 const showStateView = (items) => {
   const itemByState = showStateAllTemplate(items)
   $('#state-view').append(itemByState)
   createFormHandler()
+  $('#state-header').text(store.state)
+  console.log('store.state is', store.state)
+}
+
+const cancelCreate = () => {
+  $('#create-item-container').empty('')
+  // enable '+' (add new item) button once upon clicking 'cancel'
+  // $('#create-button').prop('disabled', false)
 }
 
 const showCreateform = () => {
   $('#create-item-container').append(showStateItemCreateTemplate)
+  // remove create form upon clicking 'create'
+  $('#cancel-create').on('click', cancelCreate)
+  // // disable '+' (add new item) button upon clicking
+  // $('#create-button').prop('disabled', true)
   $('#create-item').on('submit', onCreateItem)
 }
 
@@ -36,7 +47,8 @@ const createFormHandler = () => {
 }
 
 const hideMap = () => {
-  $('#map-view-container').empty()
+  // $('#map-view-container').empty()
+  $('#map-view-container').hide()
 }
 
 const getItemsSuccess = (data, region) => {
@@ -50,15 +62,13 @@ const getItemsSuccess = (data, region) => {
   // We need to pass filteredItems to showStateView rather than data.items
   showStateView({items: filteredItems})
   hideMap()
-  $('#state-header').text(store.state)
 }
 
 const getItemsFailure = (data) => {
   console.error(data)
 }
 
-
-const onCreateItem = function(event) {
+const onCreateItem = function (event) {
   event.preventDefault()
   const content = getFormFields(event.target)
 
@@ -138,11 +148,9 @@ const getmyGoalsFailure = (data) => {
   console.error(data)
 }
 
-const getItemsFailure = (data) => {
-  console.error(data)
-}
-
 const createItemSuccess = (data) => {
+  // enable '+' (add new item) button upon successful item create
+  // $('#create-button').prop('disabled', false)
   console.log('response is', data)
   // disappear form on sucess
   $('#create-item').remove()


### PR DESCRIPTION
Added cancel button for 'create' new item that removes the 'create'
form. Currently, if you click on '+' (add new item) more than once,
multiple 'create' forms will appear. The cancel button will work for
the only the initial 'create' form that appears.