### PR TITLE
Add feature to cancel 'update' form

### DIFF
--- a/assets/scripts/templates/state-all-items.handlebars
+++ b/assets/scripts/templates/state-all-items.handlebars
@@ -37,7 +37,14 @@
 
   <div class="col-sm-4">
     <div id="create-item-container" class="create-item-container">
+      <!-- Start state-item-create.handlebars -->
+      <!-- End state-item-create.handlebars -->
 
+      <!-- Start state-default-item.handlebars -->
+      <!-- End state-default-item.handlebars -->
+
+      <!-- Start state-item-update.handlebars -->
+      <!-- End state-item-update.handlebars -->
     </div>
 
   </div>

--- a/assets/scripts/templates/state-item-update.handlebars
+++ b/assets/scripts/templates/state-item-update.handlebars
@@ -17,6 +17,6 @@
     <input class="form-control" type="text" name="items[description]" placeholder="{{item.data-description}}">
     <input class="form-control" type="text" name="items[category]" placeholder="{{item.data-category}}">
     <button data-id="{{item.id}}" class="glyphicon glyphicon-ok-circle" type="submit" name="Submit"></button>
-    <button data-id="{{item.id}}" class="glyphicon glyphicon-remove-circle" type="button" name="Cancel"></button>
+    <button data-id="{{item.id}}" id="cancel-update" class="glyphicon glyphicon-remove-circle cancel-update" type="button" name="Cancel"></button>
   </fieldset>
 </form>

--- a/assets/scripts/usmap/ui.js
+++ b/assets/scripts/usmap/ui.js
@@ -62,9 +62,14 @@ const showStateView = (items) => {
 }
 
 const cancelCreate = () => {
-  console.log('store in cancelCreate is', store)
-  console.log('store.currentItems in cancelCreate is', store.currentItems)
+  // console.log('store in cancelCreate is', store)
+  // console.log('store.currentItems in cancelCreate is', store.currentItems)
   // store.currentItems here contains all items including newly created item (see createItemSuccess). Pass in this new object to refresh the list of all items on left pane (in state view)
+  showStateView(store.currentItems)
+  $('#state-header').text(store.state)
+}
+
+const cancelUpdate = () => {
   showStateView(store.currentItems)
   $('#state-header').text(store.state)
 }
@@ -96,6 +101,7 @@ const showEditForm = (event) => {
   const editFormHtml = editFormTemplate({item: placeHolders})
   $('#create-item-container').html(editFormHtml)
   editHandlers()
+  $('#cancel-update').on('click', cancelUpdate)
 }
 
 const editHandlers = () => {


### PR DESCRIPTION
Now, when a user clicks on 'Edit' and clicks on 'cancel',
the 'update' form gets replaced with a detailed view of the first item.
Next step: Joe Belmonte will debug the item sorting feature.