### PR TITLE
Fix bug for sign in>sign out> sign in cancel

### DIFF
--- a/assets/scripts/auth/events.js
+++ b/assets/scripts/auth/events.js
@@ -61,7 +61,7 @@ const addLandingHandlers = () => {
   $('#sign-in').on('submit', onSignIn)
   $('#modal-signin').on('hidden.bs.modal', function () {
     console.log('store.user is ', store.user)
-    if (store.user !== undefined) {
+    if (store.user !== undefined && store.user !== null) {
       $('#landing-view-container').html('')
       $('#main-view-container').html(mainPageNav)
       $('#sign-out').on('submit', onSignOut)


### PR DESCRIPTION
Previously, if a user signed in then signed out and then clicked the
sign in button but cancelled it, there would be a bug.